### PR TITLE
Java 21 / Spring Boot 3 cutover: merge nicehash-v3 into master

### DIFF
--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/exchange/pom.xml
+++ b/exchange/pom.xml
@@ -39,6 +39,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,19 @@
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
+
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>${junit-vintage-engine.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Java 21 / Spring Boot 3 cutover

Merges `nicehash-v3` into `master`: Java 21, Spring Boot 3, `jakarta.*`, Hibernate 6.

`master` is an ancestor of `nicehash-v3`, so this merges cleanly (fast-forward, no conflicts).

**After merge `master` runs on Java 21.** The Jenkins java17-folder jobs must be switched to JDK 21 before/together with this merge, otherwise those builds will fail.

Verified: full reactor green on the java-21 Jenkins pipeline; all services boot and have run on -dev and dev2.
