### PR TITLE
docs(rest-clients): gold-standard README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,104 @@
-# NiceHash V3 REST Clients
+# NiceHash Exchange REST Clients
 
-Build the whole project:
+Client library for the NiceHash **Exchange API** — synchronous, asynchronous, and WebSocket clients with request signing (API key/secret). Built as a small multi-module Maven project (`com.nicehash:rest-clients:1-SNAPSHOT`) and consumed by backend services that need exchange access.
 
-    mvn clean install -DskipTests
+Not to be confused with `platform-utils/platform-clients`, which holds the typed **inter-service** HTTP clients — this library targets the public Exchange API surface.
 
-Using Exchange client:
+---
 
-        OptionMap options = OptionMap.builder()
-                                     .set(Options.BASE_URL, "https://api-test.nicehash.com/exchange/")
-                                     .set(Options.KEY, "<KEY>")
-                                     .set(Options.SECRET, "<SECRET>")
-                                     .getMap();
+## Module Map
 
-        ExchangeClientFactory factory = ExchangeClientFactory.newInstance(options);
-        ExchangeClient client = factory.newClient();
-        List<Trade> trades = client.getMyTrades("LTCBTC");
+```mermaid
+flowchart LR
+    subgraph rest-clients
+        UTIL[util<br/>OptionMap, Options]
+        COMMON[common<br/>ClientFactory, callbacks,<br/>signing, ClientException]
+        DOMAIN[domain<br/>Trade, DepthEvent, DTOs]
+        EXCHANGE[exchange<br/>ExchangeClient, Async, WebSocket]
+        EXAMPLES[examples]
+    end
 
-Using Exchange async client:
+    EXCHANGE --> COMMON
+    EXCHANGE --> DOMAIN
+    COMMON --> UTIL
+    EXAMPLES --> EXCHANGE
 
-        OptionMap options = OptionMap.builder()
-                                     .set(Options.BASE_URL, "https://api-test.nicehash.com/exchange/")
-                                     .set(Options.KEY, "<KEY>")
-                                     .set(Options.SECRET, "<SECRET>")
-                                     .getMap();
+    subgraph Consumers
+        MAIN[main]
+        APIFRONT[api-front]
+        EXR[exchange-rate]
+        ACC[simple-accounting]
+    end
 
-        client.getMyTrades("LTCBTC", 100, new AbstractClientCallback<List<Trade>>() {
-            @Override
-            public void onResponse(List<Trade> trades) {
-                System.out.println("Trades = " + trades);
-            }
-        });
+    MAIN --> EXCHANGE
+    APIFRONT --> EXCHANGE
+    EXR --> EXCHANGE
+    ACC --> EXCHANGE
+```
 
-Using Exchange web-sockets:
+| Module | Provides |
+|--------|----------|
+| `util` | `OptionMap` / `Options` configuration primitives |
+| `common` | Client plumbing: `ClientFactory`, `ClientGenerator`, `ClientCallback` / `AbstractClientCallback`, `ClientException`, converters |
+| `domain` | Exchange DTOs (`Trade`, `DepthEvent`, order book types, …) |
+| `exchange` | `ExchangeClient` (sync), `ExchangeAsyncClient`, `ExchangeWebSocketClient`, `ExchangeClientFactory` |
+| `examples` | Runnable usage examples |
 
-        try (ExchangeWebSocketClient client = ExchangeClientFactory.newWebSocketClient("https://exchange-test.nicehash.com/ws")) {
-            client.onDepthEvent("LTCBTC", new AbstractClientCallback<DepthEvent>() {
-                @Override
-                public void onResponse(DepthEvent result) {
-                    System.out.println("Result = " + result);
-                }
-            });
+---
+
+## Usage
+
+### Synchronous client
+
+```java
+OptionMap options = OptionMap.builder()
+                             .set(Options.BASE_URL, "https://api-test.nicehash.com/exchange/")
+                             .set(Options.KEY, "<KEY>")
+                             .set(Options.SECRET, "<SECRET>")
+                             .getMap();
+
+ExchangeClientFactory factory = ExchangeClientFactory.newInstance(options);
+ExchangeClient client = factory.newClient();
+List<Trade> trades = client.getMyTrades("LTCBTC");
+```
+
+### Asynchronous client
+
+```java
+client.getMyTrades("LTCBTC", 100, new AbstractClientCallback<List<Trade>>() {
+    @Override
+    public void onResponse(List<Trade> trades) {
+        System.out.println("Trades = " + trades);
+    }
+});
+```
+
+### WebSocket client
+
+```java
+try (ExchangeWebSocketClient client = ExchangeClientFactory.newWebSocketClient("https://exchange-test.nicehash.com/ws")) {
+    client.onDepthEvent("LTCBTC", new AbstractClientCallback<DepthEvent>() {
+        @Override
+        public void onResponse(DepthEvent result) {
+            System.out.println("Result = " + result);
         }
+    });
+}
+```
+
+Authentication is handled by the factory from `Options.KEY` / `Options.SECRET`; per-request signing lives in `common`.
+
+---
+
+## Build
+
+```bash
+mvn clean install -DskipTests
+```
+
+## Branches
+
+| Branch | Stack |
+|--------|-------|
+| `master` | Java 21 · `jakarta.*` (the `nicehash-v3` migration has been merged in) |
+| `nicehash-v3` | Migration branch, merged into `master` and kept in sync |


### PR DESCRIPTION
Restructures the README: clarifies this is the Exchange API client library (vs platform-clients for inter-service calls), adds module map and consumer diagram, preserves the sync/async/WebSocket usage examples.